### PR TITLE
Update text

### DIFF
--- a/lang/en/availability_proctor.php
+++ b/lang/en/availability_proctor.php
@@ -190,8 +190,8 @@ $string['comment'] = 'Comment';
 $string['details'] = 'Details';
 
 // Fader screen.
-$string['fader_awaiting_proctoring'] = 'Constructor Proctor proctoring starts...';
-$string['fader_instructions'] = '<p>please wait</p>';
+$string['fader_awaiting_proctoring'] = 'Proctoring is launching.';
+$string['fader_instructions'] = '<p>Please wait and do not close the page</p>';
 $string['fader_reset'] = 'Session was reset, you need to restart the exam';
 
 // Dafault settings

--- a/lang/ru/availability_proctor.php
+++ b/lang/ru/availability_proctor.php
@@ -190,7 +190,7 @@ $string['comment'] = 'Комментарий';
 $string['details'] = 'Подробности';
 
 // Fader screen.
-$string['fader_awaiting_proctoring'] = 'Запуск прокторинга…';
+$string['fader_awaiting_proctoring'] = 'Запуск прокторинга.';
 $string['fader_instructions'] = '<p>Пожалуйста, ожидайте</p>';
 $string['fader_reset'] = 'Перезагрузите страницу, чтобы продолжить тестирование';
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'availability_proctor';
-$plugin->version = 2025052701;
+$plugin->version = 2025061001;
 $plugin->release = 'v2.0';
 $plugin->requires = 2018111800;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This pull request includes updates to improve user-facing text for proctoring instructions in both English and Russian, as well as a version bump for the `availability_proctor` plugin.

### Text updates for proctoring instructions:

* [`lang/en/availability_proctor.php`](diffhunk://#diff-47448317d1c4e0406cedec0290201bf09914c959bf1835314cf123c0d497171dL193-R194): Revised English text for proctoring instructions to improve clarity and provide additional guidance. For example, "Proctoring is launching." replaces "Constructor Proctor proctoring starts..." and instructions now include "Please wait and do not close the page."
* [`lang/ru/availability_proctor.php`](diffhunk://#diff-61768565873be6b4a9470b4727e5ac17d1738fb5efb0c29ff266ab395d12d90aL193-R193): Updated Russian text for proctoring instructions for consistency and clarity, such as replacing "Запуск прокторинга…" with "Запуск прокторинга."

### Version update:

* [`version.php`](diffhunk://#diff-0dc418129946563e59bb69680a5ef0ded4329ed9e56e3d295c25e12ea726726bL28-R28): Updated the plugin version from `2025052701` to `2025061001` to reflect the new changes.